### PR TITLE
Support Zig 0.11.0

### DIFF
--- a/Lesson01/build.zig
+++ b/Lesson01/build.zig
@@ -21,7 +21,7 @@ pub fn build(b: *Builder) void {
         .linux => {
             exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
             exe.linkSystemLibrary("c");
-            exe.linkSystemLibrary("gl");
+            exe.linkSystemLibrary("GL");
         },
         else => {
             @panic("don't know how to build on your system");

--- a/Lesson01/build.zig
+++ b/Lesson01/build.zig
@@ -1,25 +1,29 @@
 const std = @import("std");
 const currentTarget = @import("builtin").target;
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("Lesson01", "src/main.zig");
-    exe.setBuildMode(mode);
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
-    exe.addIncludePath("/usr/local/include");
+    const exe = b.addExecutable(.{
+        .name = "Lesson01",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
     switch (currentTarget.os.tag) {
         .macos => {
-            exe.addFrameworkDir("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks");
+            exe.addFrameworkPath(.{ .path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks" });
             exe.linkFramework("OpenGL");
         },
         .freebsd => {
-            exe.addIncludePath("/usr/local/include/GL");
+            exe.addIncludePath(.{ .path = "/usr/local/include/GL" });
             exe.linkSystemLibrary("gl");
             exe.linkSystemLibrary("glu");
         },
         .linux => {
-            exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
+            exe.addLibraryPath(.{ .path = "/usr/lib/x86_64-linux-gnu" });
             exe.linkSystemLibrary("c");
             exe.linkSystemLibrary("GL");
         },
@@ -27,11 +31,12 @@ pub fn build(b: *Builder) void {
             @panic("don't know how to build on your system");
         },
     }
+    exe.addIncludePath(.{ .path = "/usr/local/include" });
     exe.linkSystemLibrary("glfw");
 
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     const run_step = b.step("run", "Run the app");

--- a/Lesson01/src/main.zig
+++ b/Lesson01/src/main.zig
@@ -35,7 +35,9 @@ fn init_gl() void {
     c.glMatrixMode(c.GL_PROJECTION);                    // Select The Projection Matrix
     c.glLoadIdentity();
 
-    var aspect_ratio: f32 = @intToFloat(f32, height) / @intToFloat(f32, width);
+    const fHeight: f32 = @floatFromInt(height);
+    const fWidth: f32 = @floatFromInt(width);
+    const aspect_ratio = fHeight / fWidth;
     perspectiveGL(45.0, (1.0 / aspect_ratio), 0.1, 100.0);
 
     c.glMatrixMode(c.GL_MODELVIEW);

--- a/Lesson02/build.zig
+++ b/Lesson02/build.zig
@@ -21,7 +21,7 @@ pub fn build(b: *Builder) void {
         .linux => {
             exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
             exe.linkSystemLibrary("c");
-            exe.linkSystemLibrary("gl");
+            exe.linkSystemLibrary("GL");
         },
         else => {
             @panic("don't know how to build on your system");

--- a/Lesson02/build.zig
+++ b/Lesson02/build.zig
@@ -1,25 +1,29 @@
 const std = @import("std");
 const currentTarget = @import("builtin").target;
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("Lesson02", "src/main.zig");
-    exe.setBuildMode(mode);
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
-    exe.addIncludePath("/usr/local/include");
+    const exe = b.addExecutable(.{
+        .name = "Lesson02",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
     switch (currentTarget.os.tag) {
         .macos => {
-            exe.addFrameworkDir("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks");
+            exe.addFrameworkPath(.{ .path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks" });
             exe.linkFramework("OpenGL");
         },
         .freebsd => {
-            exe.addIncludePath("/usr/local/include/GL");
+            exe.addIncludePath(.{ .path = "/usr/local/include/GL" });
             exe.linkSystemLibrary("gl");
             exe.linkSystemLibrary("glu");
         },
         .linux => {
-            exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
+            exe.addLibraryPath(.{ .path = "/usr/lib/x86_64-linux-gnu" });
             exe.linkSystemLibrary("c");
             exe.linkSystemLibrary("GL");
         },
@@ -27,11 +31,12 @@ pub fn build(b: *Builder) void {
             @panic("don't know how to build on your system");
         },
     }
+    exe.addIncludePath(.{ .path = "/usr/local/include" });
     exe.linkSystemLibrary("glfw");
 
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     const run_step = b.step("run", "Run the app");

--- a/Lesson02/src/main.zig
+++ b/Lesson02/src/main.zig
@@ -34,7 +34,9 @@ fn perspectiveGL(fovY: f64, aspect: f64, zNear: f64, zFar: f64) void {
 fn init_gl() void {
     c.glMatrixMode(c.GL_PROJECTION);                    // Select The Projection Matrix
     c.glLoadIdentity();
-    var aspect_ratio: f32 = @intToFloat(f32, height) / @intToFloat(f32, width);
+    const fHeight: f32 = @floatFromInt(height);
+    const fWidth: f32 = @floatFromInt(width);
+    const aspect_ratio = fHeight / fWidth;
     perspectiveGL(45.0, (1.0 / aspect_ratio), 0.1, 100.0);
     c.glMatrixMode(c.GL_MODELVIEW);
     c.glShadeModel(c.GL_SMOOTH);                        // Enables Smooth Shading

--- a/Lesson03/build.zig
+++ b/Lesson03/build.zig
@@ -20,7 +20,7 @@ pub fn build(b: *Builder) void {
         .linux => {
             exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
             exe.linkSystemLibrary("c");
-            exe.linkSystemLibrary("gl");
+            exe.linkSystemLibrary("GL");
         },
         else => {
             @panic("don't know how to build on your system");

--- a/Lesson03/build.zig
+++ b/Lesson03/build.zig
@@ -1,24 +1,29 @@
 const std = @import("std");
 const currentTarget = @import("builtin").target;
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("Lesson03", "src/main.zig");
-    exe.setBuildMode(mode);
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "Lesson03",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     switch (currentTarget.os.tag) {
         .macos => {
-            exe.addFrameworkDir("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks");
+            exe.addFrameworkPath(.{ .path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks" });
             exe.linkFramework("OpenGL");
         },
         .freebsd => {
-            exe.addIncludePath("/usr/local/include/GL");
+            exe.addIncludePath(.{ .path = "/usr/local/include/GL" });
             exe.linkSystemLibrary("gl");
             exe.linkSystemLibrary("glu");
         },
         .linux => {
-            exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
+            exe.addLibraryPath(.{ .path = "/usr/lib/x86_64-linux-gnu" });
             exe.linkSystemLibrary("c");
             exe.linkSystemLibrary("GL");
         },
@@ -26,12 +31,12 @@ pub fn build(b: *Builder) void {
             @panic("don't know how to build on your system");
         },
     }
-    exe.addIncludePath("/usr/local/include");
+    exe.addIncludePath(.{ .path = "/usr/local/include" });
     exe.linkSystemLibrary("glfw");
 
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     const run_step = b.step("run", "Run the app");

--- a/Lesson03/src/main.zig
+++ b/Lesson03/src/main.zig
@@ -34,7 +34,9 @@ fn perspectiveGL(fovY: f64, aspect: f64, zNear: f64, zFar: f64) void {
 fn init_gl() void {
     c.glMatrixMode(c.GL_PROJECTION);                    // Select The Projection Matrix
     c.glLoadIdentity();
-    var aspect_ratio: f32 = @intToFloat(f32, height) / @intToFloat(f32, width);
+    const fHeight: f32 = @floatFromInt(height);
+    const fWidth: f32 = @floatFromInt(width);
+    const aspect_ratio = fHeight / fWidth;
     perspectiveGL(45.0, (1.0 / aspect_ratio), 0.1, 100.0);
     c.glMatrixMode(c.GL_MODELVIEW);
     c.glShadeModel(c.GL_SMOOTH);                        // Enables Smooth Shading

--- a/Lesson04/build.zig
+++ b/Lesson04/build.zig
@@ -20,7 +20,7 @@ pub fn build(b: *Builder) void {
         .linux => {
             exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
             exe.linkSystemLibrary("c");
-            exe.linkSystemLibrary("gl");
+            exe.linkSystemLibrary("GL");
         },
         else => {
             @panic("don't know how to build on your system");

--- a/Lesson04/build.zig
+++ b/Lesson04/build.zig
@@ -1,24 +1,29 @@
 const std = @import("std");
 const currentTarget = @import("builtin").target;
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("Lesson04", "src/main.zig");
-    exe.setBuildMode(mode);
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "Lesson04",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     switch (currentTarget.os.tag) {
         .macos => {
-            exe.addFrameworkDir("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks");
+            exe.addFrameworkPath(.{ .path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks" });
             exe.linkFramework("OpenGL");
         },
         .freebsd => {
-            exe.addIncludePath("/usr/local/include/GL");
+            exe.addIncludePath(.{ .path = "/usr/local/include/GL" });
             exe.linkSystemLibrary("gl");
             exe.linkSystemLibrary("glu");
         },
         .linux => {
-            exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
+            exe.addLibraryPath(.{ .path = "/usr/lib/x86_64-linux-gnu" });
             exe.linkSystemLibrary("c");
             exe.linkSystemLibrary("GL");
         },
@@ -26,12 +31,12 @@ pub fn build(b: *Builder) void {
             @panic("don't know how to build on your system");
         },
     }
-    exe.addIncludePath("/usr/local/include");
+    exe.addIncludePath(.{ .path = "/usr/local/include" });
     exe.linkSystemLibrary("glfw");
 
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     const run_step = b.step("run", "Run the app");

--- a/Lesson04/src/main.zig
+++ b/Lesson04/src/main.zig
@@ -36,7 +36,9 @@ fn perspectiveGL(fovY: f64, aspect: f64, zNear: f64, zFar: f64) void {
 fn init_gl() void {
     c.glMatrixMode(c.GL_PROJECTION);                    // Select The Projection Matrix
     c.glLoadIdentity();
-    var aspect_ratio: f32 = @intToFloat(f32, height) / @intToFloat(f32, width);
+    const fHeight: f32 = @floatFromInt(height);
+    const fWidth: f32 = @floatFromInt(width);
+    const aspect_ratio = fHeight / fWidth;
     perspectiveGL(45.0, (1.0 / aspect_ratio), 0.1, 100.0);
     c.glMatrixMode(c.GL_MODELVIEW);
     c.glShadeModel(c.GL_SMOOTH);                        // Enables Smooth Shading

--- a/Lesson05/build.zig
+++ b/Lesson05/build.zig
@@ -20,7 +20,7 @@ pub fn build(b: *Builder) void {
         .linux => {
             exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
             exe.linkSystemLibrary("c");
-            exe.linkSystemLibrary("gl");
+            exe.linkSystemLibrary("GL");
         },
         else => {
             @panic("don't know how to build on your system");

--- a/Lesson05/build.zig
+++ b/Lesson05/build.zig
@@ -1,24 +1,29 @@
 const std = @import("std");
 const currentTarget = @import("builtin").target;
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("Lesson05", "src/main.zig");
-    exe.setBuildMode(mode);
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "Lesson05",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     switch (currentTarget.os.tag) {
         .macos => {
-            exe.addFrameworkDir("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks");
+            exe.addFrameworkPath(.{ .path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks" });
             exe.linkFramework("OpenGL");
         },
         .freebsd => {
-            exe.addIncludePath("/usr/local/include/GL");
+            exe.addIncludePath(.{ .path = "/usr/local/include/GL" });
             exe.linkSystemLibrary("gl");
             exe.linkSystemLibrary("glu");
         },
         .linux => {
-            exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
+            exe.addLibraryPath(.{ .path = "/usr/lib/x86_64-linux-gnu" });
             exe.linkSystemLibrary("c");
             exe.linkSystemLibrary("GL");
         },
@@ -26,12 +31,12 @@ pub fn build(b: *Builder) void {
             @panic("don't know how to build on your system");
         },
     }
-    exe.addIncludePath("/usr/local/include");
+    exe.addIncludePath(.{ .path = "/usr/local/include" });
     exe.linkSystemLibrary("glfw");
 
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     const run_step = b.step("run", "Run the app");

--- a/Lesson05/src/main.zig
+++ b/Lesson05/src/main.zig
@@ -36,7 +36,9 @@ fn perspectiveGL(fovY: f64, aspect: f64, zNear: f64, zFar: f64) void {
 fn init_gl() void {
     c.glMatrixMode(c.GL_PROJECTION);                    // Select The Projection Matrix
     c.glLoadIdentity();
-    var aspect_ratio: f32 = @intToFloat(f32, height) / @intToFloat(f32, width);
+    const fHeight: f32 = @floatFromInt(height);
+    const fWidth: f32 = @floatFromInt(width);
+    const aspect_ratio = fHeight / fWidth;
     perspectiveGL(45.0, (1.0 / aspect_ratio), 0.1, 100.0);
     c.glMatrixMode(c.GL_MODELVIEW);
     c.glShadeModel(c.GL_SMOOTH);                        // Enables Smooth Shading

--- a/Lesson06/build.zig
+++ b/Lesson06/build.zig
@@ -23,7 +23,7 @@ pub fn build(b: *Builder) void {
         .linux => {
             exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
             exe.linkSystemLibrary("c");
-            exe.linkSystemLibrary("gl");
+            exe.linkSystemLibrary("GL");
         },
         else => {
             @panic("don't know how to build on your system");

--- a/Lesson06/build.zig
+++ b/Lesson06/build.zig
@@ -1,27 +1,34 @@
 const std = @import("std");
 const currentTarget = @import("builtin").target;
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("Lesson06", "src/main.zig");
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
-    exe.addCSourceFile("stb_image-2.23/stb_image_impl.c", &[_][]const u8{"-std=c99"});
+    const exe = b.addExecutable(.{
+        .name = "Lesson06",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
-    exe.setBuildMode(mode);
+    exe.addCSourceFile(.{
+        .file = .{ .path = "stb_image-2.23/stb_image_impl.c" },
+        .flags = &[_][]const u8{"-std=c99"},
+    });
 
     switch (currentTarget.os.tag) {
         .macos => {
-            exe.addFrameworkDir("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks");
+            exe.addFrameworkPath(.{ .path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks" });
             exe.linkFramework("OpenGL");
         },
         .freebsd => {
-            exe.addIncludePath("/usr/local/include/GL");
+            exe.addIncludePath(.{ .path = "/usr/local/include/GL" });
             exe.linkSystemLibrary("gl");
             exe.linkSystemLibrary("glu");
         },
         .linux => {
-            exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
+            exe.addLibraryPath(.{ .path = "/usr/lib/x86_64-linux-gnu" });
             exe.linkSystemLibrary("c");
             exe.linkSystemLibrary("GL");
         },
@@ -29,13 +36,13 @@ pub fn build(b: *Builder) void {
             @panic("don't know how to build on your system");
         },
     }
-    exe.addIncludePath("stb_image-2.23");
-    exe.addIncludePath("/usr/local/include");
+    exe.addIncludePath(.{ .path = "stb_image-2.23" });
+    exe.addIncludePath(.{ .path = "/usr/local/include" });
     exe.linkSystemLibrary("glfw");
 
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     const run_step = b.step("run", "Run the app");

--- a/Lesson06/src/main.zig
+++ b/Lesson06/src/main.zig
@@ -54,12 +54,12 @@ fn load_texture() !void {
         c.GL_TEXTURE_2D,
         0,
         c.GL_RGBA,
-        @intCast(c_int, img.width),
-        @intCast(c_int, img.height),
+        @intCast(img.width),
+        @intCast(img.height),
         0,
         c.GL_RGBA,
         c.GL_UNSIGNED_BYTE,
-        @ptrCast(*anyopaque, &img.raw[0]),
+        @ptrCast(&img.raw[0]),
     );
 
 }
@@ -71,7 +71,9 @@ fn init_gl() void {
 
     c.glMatrixMode(c.GL_PROJECTION);                    // Select The Projection Matrix
     c.glLoadIdentity();
-    var aspect_ratio: f32 = @intToFloat(f32, height) / @intToFloat(f32, width);
+    const fHeight: f32 = @floatFromInt(height);
+    const fWidth: f32 = @floatFromInt(width);
+    const aspect_ratio = fHeight / fWidth;
     perspectiveGL(45.0, (1.0 / aspect_ratio), 0.1, 100.0);
     c.glMatrixMode(c.GL_MODELVIEW);
     c.glEnable(c.GL_TEXTURE_2D);

--- a/Lesson06/src/png.zig
+++ b/Lesson06/src/png.zig
@@ -17,24 +17,24 @@ pub const PngImage = struct {
         var width: c_int = undefined;
         var height: c_int = undefined;
 
-        if (c.stbi_info_from_memory(compressed_bytes.ptr, @intCast(c_int, compressed_bytes.len), &width, &height, null) == 0) {
+        if (c.stbi_info_from_memory(compressed_bytes.ptr, @intCast(compressed_bytes.len), &width, &height, null) == 0) {
             return error.NotPngFile;
         }
 
         if (width <= 0 or height <= 0) return error.NoPixels;
-        pi.width = @intCast(u32, width);
-        pi.height = @intCast(u32, height);
+        pi.width = @intCast(width);
+        pi.height = @intCast(height);
 
         // Not validating channel_count because it gets auto-converted to 4
 
-        if (c.stbi_is_16_bit_from_memory(compressed_bytes.ptr, @intCast(c_int, compressed_bytes.len)) != 0) {
+        if (c.stbi_is_16_bit_from_memory(compressed_bytes.ptr, @intCast(compressed_bytes.len)) != 0) {
             return error.InvalidFormat;
         }
         const bits_per_channel = 8;
         const channel_count = 4;
 
         c.stbi_set_flip_vertically_on_load(1);
-        const image_data = c.stbi_load_from_memory(compressed_bytes.ptr, @intCast(c_int, compressed_bytes.len), &width, &height, null, channel_count);
+        const image_data = c.stbi_load_from_memory(compressed_bytes.ptr, @intCast(compressed_bytes.len), &width, &height, null, channel_count);
 
         if (image_data == null) return error.NoMem;
 

--- a/Lesson07/build.zig
+++ b/Lesson07/build.zig
@@ -1,28 +1,35 @@
 const std = @import("std");
 const currentTarget = @import("builtin").target;
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("Lesson07", "src/main.zig");
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
-    exe.addCSourceFile("stb_image-2.23/stb_image_impl.c", &[_][]const u8{"-std=c99"});
+    const exe = b.addExecutable(.{
+        .name = "Lesson07",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
-    exe.setBuildMode(mode);
+    exe.addCSourceFile(.{
+        .file = .{ .path = "stb_image-2.23/stb_image_impl.c" },
+        .flags = &[_][]const u8{"-std=c99"},
+    });
 
     switch (currentTarget.os.tag) {
         .macos => {
-            exe.addFrameworkDir("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks");
+            exe.addFrameworkPath(.{ .path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks" });
             exe.addIncludePath("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Headers");
             exe.linkFramework("OpenGL");
         },
         .freebsd => {
-            exe.addIncludePath("/usr/local/include/GL");
+            exe.addIncludePath(.{ .path = "/usr/local/include/GL" });
             exe.linkSystemLibrary("gl");
             exe.linkSystemLibrary("glu");
         },
         .linux => {
-            exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
+            exe.addLibraryPath(.{ .path = "/usr/lib/x86_64-linux-gnu" });
             exe.linkSystemLibrary("c");
             exe.linkSystemLibrary("GL");
             exe.linkSystemLibrary("GLU");
@@ -31,13 +38,13 @@ pub fn build(b: *Builder) void {
             @panic("don't know how to build on your system");
         },
     }
-    exe.addIncludePath("stb_image-2.23");
-    exe.addIncludePath("/usr/local/include");
+    exe.addIncludePath(.{ .path = "stb_image-2.23" });
+    exe.addIncludePath(.{ .path = "/usr/local/include" });
     exe.linkSystemLibrary("glfw");
 
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     const run_step = b.step("run", "Run the app");

--- a/Lesson07/build.zig
+++ b/Lesson07/build.zig
@@ -24,8 +24,8 @@ pub fn build(b: *Builder) void {
         .linux => {
             exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
             exe.linkSystemLibrary("c");
-            exe.linkSystemLibrary("gl");
-            exe.linkSystemLibrary("glu");
+            exe.linkSystemLibrary("GL");
+            exe.linkSystemLibrary("GLU");
         },
         else => {
             @panic("don't know how to build on your system");

--- a/Lesson07/src/main.zig
+++ b/Lesson07/src/main.zig
@@ -84,12 +84,12 @@ fn load_textures() !void {
         c.GL_TEXTURE_2D,
         0,
         c.GL_RGBA,
-        @intCast(c_int, img.width),
-        @intCast(c_int, img.height),
+        @intCast(img.width),
+        @intCast(img.height),
         0,
         c.GL_RGBA,
         c.GL_UNSIGNED_BYTE,
-        @ptrCast(*anyopaque, &img.raw[0]),
+        @ptrCast(&img.raw[0]),
     );
 
     c.glBindTexture(c.GL_TEXTURE_2D, texture[1]);
@@ -99,12 +99,12 @@ fn load_textures() !void {
         c.GL_TEXTURE_2D,
         0,
         c.GL_RGBA,
-        @intCast(c_int, img.width),
-        @intCast(c_int, img.height),
+        @intCast(img.width),
+        @intCast(img.height),
         0,
         c.GL_RGBA,
         c.GL_UNSIGNED_BYTE,
-        @ptrCast(*anyopaque, &img.raw[0]),
+        @ptrCast(&img.raw[0]),
     );
 
     c.glBindTexture(c.GL_TEXTURE_2D, texture[2]);
@@ -113,11 +113,11 @@ fn load_textures() !void {
     _ = c.gluBuild2DMipmaps(
         c.GL_TEXTURE_2D,
         c.GL_RGBA,
-        @intCast(c_int, img.width),
-        @intCast(c_int, img.height),
+        @intCast(img.width),
+        @intCast(img.height),
         c.GL_RGBA,
         c.GL_UNSIGNED_BYTE,
-        @ptrCast(*anyopaque, &img.raw[0]),
+        @ptrCast(&img.raw[0]),
     );
 }
 
@@ -129,7 +129,9 @@ fn init_gl() void {
     c.glViewport(0, 0, width, height);
     c.glMatrixMode(c.GL_PROJECTION);                        // Select The Projection Matrix
     c.glLoadIdentity();
-    var aspect_ratio: f32 = @intToFloat(f32, height) / @intToFloat(f32, width);
+    const fHeight: f32 = @floatFromInt(height);
+    const fWidth: f32 = @floatFromInt(width);
+    const aspect_ratio = fHeight / fWidth;
     perspectiveGL(45.0, (1.0 / aspect_ratio), 0.1, 100.0);
     c.glMatrixMode(c.GL_MODELVIEW);
     c.glLoadIdentity();

--- a/Lesson07/src/png.zig
+++ b/Lesson07/src/png.zig
@@ -17,24 +17,24 @@ pub const PngImage = struct {
         var width: c_int = undefined;
         var height: c_int = undefined;
 
-        if (c.stbi_info_from_memory(compressed_bytes.ptr, @intCast(c_int, compressed_bytes.len), &width, &height, null) == 0) {
+        if (c.stbi_info_from_memory(compressed_bytes.ptr, @intCast(compressed_bytes.len), &width, &height, null) == 0) {
             return error.NotPngFile;
         }
 
         if (width <= 0 or height <= 0) return error.NoPixels;
-        pi.width = @intCast(u32, width);
-        pi.height = @intCast(u32, height);
+        pi.width = @intCast(width);
+        pi.height = @intCast(height);
 
         // Not validating channel_count because it gets auto-converted to 4
 
-        if (c.stbi_is_16_bit_from_memory(compressed_bytes.ptr, @intCast(c_int, compressed_bytes.len)) != 0) {
+        if (c.stbi_is_16_bit_from_memory(compressed_bytes.ptr, @intCast(compressed_bytes.len)) != 0) {
             return error.InvalidFormat;
         }
         const bits_per_channel = 8;
         const channel_count = 4;
 
         c.stbi_set_flip_vertically_on_load(1);
-        const image_data = c.stbi_load_from_memory(compressed_bytes.ptr, @intCast(c_int, compressed_bytes.len), &width, &height, null, channel_count);
+        const image_data = c.stbi_load_from_memory(compressed_bytes.ptr, @intCast(compressed_bytes.len), &width, &height, null, channel_count);
 
         if (image_data == null) return error.NoMem;
 

--- a/Lesson08/build.zig
+++ b/Lesson08/build.zig
@@ -1,28 +1,35 @@
 const std = @import("std");
 const currentTarget = @import("builtin").target;
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("Lesson07", "src/main.zig");
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
-    exe.addCSourceFile("stb_image-2.23/stb_image_impl.c", &[_][]const u8{"-std=c99"});
+    const exe = b.addExecutable(.{
+        .name = "Lesson08",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
-    exe.setBuildMode(mode);
+    exe.addCSourceFile(.{
+        .file = .{ .path = "stb_image-2.23/stb_image_impl.c" },
+        .flags = &[_][]const u8{"-std=c99"},
+    });
 
     switch (currentTarget.os.tag) {
         .macos => {
-            exe.addFrameworkDir("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks");
+            exe.addFrameworkPath(.{ .path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks" });
             exe.addIncludePath("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Headers");
             exe.linkFramework("OpenGL");
         },
         .freebsd => {
-            exe.addIncludePath("/usr/local/include/GL");
+            exe.addIncludePath(.{ .path = "/usr/local/include/GL" });
             exe.linkSystemLibrary("gl");
             exe.linkSystemLibrary("glu");
         },
         .linux => {
-            exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
+            exe.addLibraryPath(.{ .path = "/usr/lib/x86_64-linux-gnu" });
             exe.linkSystemLibrary("c");
             exe.linkSystemLibrary("GL");
             exe.linkSystemLibrary("GLU");
@@ -31,13 +38,13 @@ pub fn build(b: *Builder) void {
             @panic("don't know how to build on your system");
         },
     }
-    exe.addIncludePath("stb_image-2.23");
-    exe.addIncludePath("/usr/local/include");
+    exe.addIncludePath(.{ .path = "stb_image-2.23" });
+    exe.addIncludePath(.{ .path = "/usr/local/include" });
     exe.linkSystemLibrary("glfw");
 
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     const run_step = b.step("run", "Run the app");

--- a/Lesson08/build.zig
+++ b/Lesson08/build.zig
@@ -24,8 +24,8 @@ pub fn build(b: *Builder) void {
         .linux => {
             exe.addLibraryPath("/usr/lib/x86_64-linux-gnu");
             exe.linkSystemLibrary("c");
-            exe.linkSystemLibrary("gl");
-            exe.linkSystemLibrary("glu");
+            exe.linkSystemLibrary("GL");
+            exe.linkSystemLibrary("GLU");
         },
         else => {
             @panic("don't know how to build on your system");

--- a/Lesson08/src/main.zig
+++ b/Lesson08/src/main.zig
@@ -95,12 +95,12 @@ fn load_textures() !void {
         c.GL_TEXTURE_2D,
         0,
         c.GL_RGBA,
-        @intCast(c_int, img.width),
-        @intCast(c_int, img.height),
+        @intCast(img.width),
+        @intCast(img.height),
         0,
         c.GL_RGBA,
         c.GL_UNSIGNED_BYTE,
-        @ptrCast(*anyopaque, &img.raw[0]),
+        @ptrCast(&img.raw[0]),
     );
 
     c.glBindTexture(c.GL_TEXTURE_2D, texture[1]);
@@ -110,12 +110,12 @@ fn load_textures() !void {
         c.GL_TEXTURE_2D,
         0,
         c.GL_RGBA,
-        @intCast(c_int, img.width),
-        @intCast(c_int, img.height),
+        @intCast(img.width),
+        @intCast(img.height),
         0,
         c.GL_RGBA,
         c.GL_UNSIGNED_BYTE,
-        @ptrCast(*anyopaque, &img.raw[0]),
+        @ptrCast(&img.raw[0]),
     );
 
     c.glBindTexture(c.GL_TEXTURE_2D, texture[2]);
@@ -124,11 +124,11 @@ fn load_textures() !void {
     _ = c.gluBuild2DMipmaps(
         c.GL_TEXTURE_2D,
         c.GL_RGBA,
-        @intCast(c_int, img.width),
-        @intCast(c_int, img.height),
+        @intCast(img.width),
+        @intCast(img.height),
         c.GL_RGBA,
         c.GL_UNSIGNED_BYTE,
-        @ptrCast(*anyopaque, &img.raw[0]),
+        @ptrCast(&img.raw[0]),
     );
 }
 
@@ -140,7 +140,9 @@ fn init_gl() void {
     c.glViewport(0, 0, width, height);
     c.glMatrixMode(c.GL_PROJECTION);                        // Select The Projection Matrix
     c.glLoadIdentity();
-    var aspect_ratio: f32 = @intToFloat(f32, height) / @intToFloat(f32, width);
+    const fHeight: f32 = @floatFromInt(height);
+    const fWidth: f32 = @floatFromInt(width);
+    const aspect_ratio = fHeight / fWidth;
     perspectiveGL(45.0, (1.0 / aspect_ratio), 0.1, 100.0);
     c.glMatrixMode(c.GL_MODELVIEW);
     c.glLoadIdentity();

--- a/Lesson08/src/png.zig
+++ b/Lesson08/src/png.zig
@@ -17,24 +17,24 @@ pub const PngImage = struct {
         var width: c_int = undefined;
         var height: c_int = undefined;
 
-        if (c.stbi_info_from_memory(compressed_bytes.ptr, @intCast(c_int, compressed_bytes.len), &width, &height, null) == 0) {
+        if (c.stbi_info_from_memory(compressed_bytes.ptr, @intCast(compressed_bytes.len), &width, &height, null) == 0) {
             return error.NotPngFile;
         }
 
         if (width <= 0 or height <= 0) return error.NoPixels;
-        pi.width = @intCast(u32, width);
-        pi.height = @intCast(u32, height);
+        pi.width = @intCast(width);
+        pi.height = @intCast(height);
 
         // Not validating channel_count because it gets auto-converted to 4
 
-        if (c.stbi_is_16_bit_from_memory(compressed_bytes.ptr, @intCast(c_int, compressed_bytes.len)) != 0) {
+        if (c.stbi_is_16_bit_from_memory(compressed_bytes.ptr, @intCast(compressed_bytes.len)) != 0) {
             return error.InvalidFormat;
         }
         const bits_per_channel = 8;
         const channel_count = 4;
 
         c.stbi_set_flip_vertically_on_load(1);
-        const image_data = c.stbi_load_from_memory(compressed_bytes.ptr, @intCast(c_int, compressed_bytes.len), &width, &height, null, channel_count);
+        const image_data = c.stbi_load_from_memory(compressed_bytes.ptr, @intCast(compressed_bytes.len), &width, &height, null, channel_count);
 
         if (image_data == null) return error.NoMem;
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The ancient NeHe OpenGL tutorials, ported to the Zig language.
 
 Based largely on the C-based [glfw 2 NeHe tutorials by Joseph Redmon (pjreddie@)](https://github.com/pjreddie/NeHe-Tutorials-Using-GLFW) with updates for glfw 3. Other useful base material from [andrewrk/tetris](https://github.com/andrewrk/tetris).
 
-The build.zig files work on some versions of MacOS and FreeBSD, as well as Linux (tested on Debian 11 and Ubtuntu 22.04). With a little effort they should build on other OSes - contributions welcome. Some tweaking of build and c.zig files might be required to build on non-Linux machines.
+The build.zig files work on some versions of MacOS and FreeBSD, as well as Linux (tested on Debian 11-12 and Ubuntu 22.04). With a little effort they should build on other OSes - contributions welcome. Some tweaking of build and c.zig files might be required to build on non-Linux machines.
 
 ## Requirements
 
@@ -20,7 +20,7 @@ brew install glfw
 
 On MacOS, you will also need to install XCode in order to get the OpenGL framework.
 
-### Debian 11
+### Debian 11-12
 
 ```sh
 apt install libglfw3-dev libglu1-mesa-dev

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The build.zig files work on some versions of MacOS and FreeBSD, as well as Linux
 
 ## Requirements
 
-Tested with Zig version 0.10.1.
+Tested with Zig version 0.11.0.
 
 You will need to install [glfw](https://www.glfw.org/).
 


### PR DESCRIPTION
It's me again :)

As before, I've only tested on Linux, so someone else will need to test `.macos` and `.freebsd`.

I'm on Debian 12 this time. For some reason, I had to change `gl` and `glu` to `GL` and `GLU` in `build.zig`, even when I was still on Zig 0.10.1. I'm not sure if that's related to my Debian upgrade, or if it was just something that was previously wrongly accepted on my system and now isn't. The actual files installed in my `/usr/lib/x86_64-linux-gnu/` are capitalised (e.g. `libGL.so`) so this would imply that uppercase is correct. (Note that for `glfw`, _lowercase_ is still correct, so I have not changed this.)

The breaking changes in Zig 0.11.0 that I had to address should be pretty obvious from the diff:
- `@floatFromInt` instead of `@intToFloat`.
- Removing first argument of `@...Cast` calls.
  - I opted to make extra `const` identifiers for `fWidth` and `fHeight`, it looked cleaner than putting two `@as` calls in.
- New interfaces for anything in `build.zig` that takes a path.
- Other assorted changes to `build.zig` interfaces.
  - In Lesson01 and Lesson02, I moved the `addIncludePath` call to below the `switch` instead of above for consistency with all the others.
  - Lesson08 was wrongly named as `Lesson07` in `build.zig` for some reason. I've changed that to `Lesson08` as it should have been.